### PR TITLE
Change docker run to -i to allow non-tty builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ DOCKER_RUN=docker run \
 			--privileged \
 			-v /dev:/dev \
 			$(RUN_PROXY) \
-			-ti \
+			-i \
 			-v $(WORKDIR):/osbuilder \
 			$(IMAGE_BUILDER)
 


### PR DESCRIPTION
This is to support the creation of these images in automation
environments.

Signed-off-by: David Klimesh <david.j.klimesh@intel.com>