### PR TITLE
Add iptable bin utilities to the base image.

### DIFF
--- a/scripts/osbuilder.sh
+++ b/scripts/osbuilder.sh
@@ -53,7 +53,7 @@ build_rootfs()
 {
     mkdir -p "${ROOTFS_DIR}"
     DNF="dnf --config=$DNF_CONF -y --installroot=${ROOTFS_DIR} --noplugins"
-	$DNF install systemd hyperstart cc-oci-runtime-extras coreutils systemd-bootchart
+	$DNF install systemd hyperstart cc-oci-runtime-extras coreutils systemd-bootchart iptables-bin
 }
 
 build_kernel()


### PR DESCRIPTION
Required for applying iptable rules for the container.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>