### PR TITLE
image: Increase image size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ However, it is still possible to [run the scripts using docker](#Using-osbuilder
 ## Environment Variables
 
 * `EXTRA_PKGS`: The list of extra packages to install separated by spaces, for example "`a b c`". By default this values is empty.
-* `IMG_SIZE`: Image size. By default this value is `50M`.
+* `IMG_SIZE`: Image size. By default this value is `80M`.
 * `REPO_URL`: The repository URL. By default this value is `https://download.clearlinux.org/current/x86_64/os/`.
 * `USE_DOCKER`: If set, perform all build steps inside a docker container.
 * `WORKDIR`: Specify an alternative directory under which files will be generated (default `./workdir`).

--- a/scripts/image_builder.sh
+++ b/scripts/image_builder.sh
@@ -51,7 +51,7 @@ exit 1
 # Image file to be created:
 IMAGE="container.img"
 # Image contents source folder
-IMG_SIZE=${IMG_SIZE:-50M}
+IMG_SIZE=${IMG_SIZE:-80M}
 BLOCK_SIZE=${BLOCK_SIZE:-4096}
 
 #Create image file


### PR DESCRIPTION
The default image size is very small leting the agent to
do some operations in storage.

Increase to allow the agent run.

Fixes: #27

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>