### PR TITLE
packages: add procps-ng-bin package

### DIFF
--- a/scripts/osbuilder.sh
+++ b/scripts/osbuilder.sh
@@ -126,7 +126,8 @@ build_rootfs()
 		coreutils-bin \
 		systemd-bootchart \
 		iptables-bin \
-		clear-containers-agent
+		clear-containers-agent \
+		procps-ng-bin
 
 	[ -n "${ROOTFS_DIR}" ]  && rm -r "${ROOTFS_DIR}/var/cache/dnf"
 }


### PR DESCRIPTION
procps-ng-bin includes the ps command that is needed to list the processes
inside the container and used by ```cc-runtime ps``` and ```docker top```

fixes #40

Signed-off-by: Julio Montes <julio.montes@intel.com>